### PR TITLE
Add missing setuptools_scm build-time dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: f99ff44568805d5c00c0599019302a4ea4874d861f00996c8b7de6de4d543f7b
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -19,6 +19,8 @@ requirements:
   host:
     - python {{ python_min }}
     - pip
+    - setuptools >=61
+    - setuptools_scm >=3.4
   run:
     - python >={{ python_min }}
     - beautifulsoup4 >=4.9.1
@@ -38,6 +40,7 @@ test:
     - siphon.simplewebservice.wyoming
   commands:
     - pip check
+    - python -c "import siphon; print(siphon.__version__)"
   requires:
     - python {{ python_min }}
     - pip


### PR DESCRIPTION
This should fix the package version metadata. Fixes #24.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
